### PR TITLE
Add STS auth, auth profiles, and the default auth chain to AWS S3 endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,8 @@ dependencies {
             "org.xerial:sqlite-jdbc:3.8.11.1",
             project(':ecs-sync-model')
     testCompile "junit:junit:4.11",
-            "org.hsqldb:hsqldb:2.3.2"
+            "org.hsqldb:hsqldb:2.3.2",
+            "com.amazonaws:aws-java-sdk-sts:1.11.714"
 }
 
 compileJava {

--- a/ecs-sync-model/src/main/java/com/emc/ecs/sync/config/storage/AwsS3Config.java
+++ b/ecs-sync-model/src/main/java/com/emc/ecs/sync/config/storage/AwsS3Config.java
@@ -55,6 +55,8 @@ public class AwsS3Config extends AbstractConfig {
     private String host;
     private int port = -1;
     private String region;
+    private boolean useDefaultCredentialsProvider;
+    private String profile;
     private String accessKey;
     private String secretKey;
     private String sessionToken;
@@ -141,7 +143,7 @@ public class AwsS3Config extends AbstractConfig {
         this.port = port;
     }
 
-    @Option(orderIndex = 35, advanced = true, description = "Overrides the AWS region that would be inferred from the endpoint")
+    @Option(orderIndex = 33, advanced = true, description = "Overrides the AWS region that would be inferred from the endpoint")
     public String getRegion() {
         return region;
     }
@@ -150,7 +152,26 @@ public class AwsS3Config extends AbstractConfig {
         this.region = region;
     }
 
-    @Option(orderIndex = 40, locations = Option.Location.Form, required = true, description = "The S3 access key")
+
+    @Option(orderIndex = 35, locations = Option.Location.Form, advanced = true, description = "Use S3 default credentials provider")
+    public boolean getUseDefaultCredentialsProvider() {
+        return useDefaultCredentialsProvider;
+    }
+
+    public void setUseDefaultCredentialsProvider(boolean useDefaultCredentialsProvider) {
+        this.useDefaultCredentialsProvider = useDefaultCredentialsProvider;
+    }
+
+    @Option(orderIndex = 37, locations = Option.Location.Form, advanced = true, sensitive = true, description = "Add profile credentials provider for the given profile")
+    public String getProfile() {
+        return profile;
+    }
+
+    public void setProfile(String profile) {
+        this.profile = profile;
+    }
+
+    @Option(orderIndex = 40, locations = Option.Location.Form, description = "The S3 access key")
     public String getAccessKey() {
         return accessKey;
     }
@@ -159,7 +180,7 @@ public class AwsS3Config extends AbstractConfig {
         this.accessKey = accessKey;
     }
 
-    @Option(orderIndex = 50, locations = Option.Location.Form, required = true, sensitive = true, description = "The secret key for the specified access key")
+    @Option(orderIndex = 50, locations = Option.Location.Form, sensitive = true, description = "The secret key for the specified access key")
     public String getSecretKey() {
         return secretKey;
     }

--- a/ecs-sync-model/src/main/java/com/emc/ecs/sync/config/storage/AwsS3Config.java
+++ b/ecs-sync-model/src/main/java/com/emc/ecs/sync/config/storage/AwsS3Config.java
@@ -36,6 +36,7 @@ import static com.emc.ecs.sync.config.storage.AwsS3Config.URI_PREFIX;
         PATTERN_DESC + "\n" +
         "Scheme, host and port are all optional. If omitted, " +
         "https://s3.amazonaws.com:443 is assumed. " +
+        "sessionToken (optional) is required for STS session credentials. " +
         "keyPrefix (optional) is the prefix under which to start " +
         "enumerating or writing keys within the bucket, e.g. dir1/. If omitted, the " +
         "root of the bucket is assumed.")
@@ -56,6 +57,7 @@ public class AwsS3Config extends AbstractConfig {
     private String region;
     private String accessKey;
     private String secretKey;
+    private String sessionToken;
     private boolean disableVHosts;
     private String bucketName;
     private boolean createBucket;
@@ -164,6 +166,15 @@ public class AwsS3Config extends AbstractConfig {
 
     public void setSecretKey(String secretKey) {
         this.secretKey = secretKey;
+    }
+
+    @Option(orderIndex = 55, locations = Option.Location.Form, advanced = true, sensitive = true, description = "The session token to use for temp credentials")
+    public String getSessionToken() {
+        return sessionToken;
+    }
+
+    public void setSessionToken(String sessionToken) {
+        this.sessionToken = sessionToken;
     }
 
     @Option(orderIndex = 60, advanced = true, description = "Specifies whether virtual hosted buckets will be disabled (and path-style buckets will be used)")

--- a/ecs-sync-model/src/main/java/com/emc/ecs/sync/config/storage/AwsS3Config.java
+++ b/ecs-sync-model/src/main/java/com/emc/ecs/sync/config/storage/AwsS3Config.java
@@ -37,6 +37,8 @@ import static com.emc.ecs.sync.config.storage.AwsS3Config.URI_PREFIX;
         "Scheme, host and port are all optional. If omitted, " +
         "https://s3.amazonaws.com:443 is assumed. " +
         "sessionToken (optional) is required for STS session credentials. " +
+        "profile (optional) will allow profile credentials provider. " +
+        "useDefaultCredentialsProvider (optional) enables default credentials provider chain. " +
         "keyPrefix (optional) is the prefix under which to start " +
         "enumerating or writing keys within the bucket, e.g. dir1/. If omitted, the " +
         "root of the bucket is assumed.")

--- a/src/main/java/com/emc/ecs/sync/storage/s3/AwsS3CredentialsProviderChain.java
+++ b/src/main/java/com/emc/ecs/sync/storage/s3/AwsS3CredentialsProviderChain.java
@@ -27,10 +27,8 @@ public class AwsS3CredentialsProviderChain extends AWSCredentialsProviderChain {
 
     public static class Builder {
         private final ArrayList<AWSCredentialsProvider> credentialProviders = new ArrayList<>();
-        private String profile;
 
         Builder() {
-            profile = null;
         }
 
         public AwsS3CredentialsProviderChain build() {

--- a/src/main/java/com/emc/ecs/sync/storage/s3/AwsS3CredentialsProviderChain.java
+++ b/src/main/java/com/emc/ecs/sync/storage/s3/AwsS3CredentialsProviderChain.java
@@ -1,0 +1,62 @@
+package com.emc.ecs.sync.storage.s3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSCredentialsProviderChain;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AwsS3CredentialsProviderChain extends AWSCredentialsProviderChain {
+    private static final EnvironmentVariableCredentialsProvider ENV_PROVIDER_INSTANCE = new EnvironmentVariableCredentialsProvider();
+    private static final SystemPropertiesCredentialsProvider SYS_PROVIDER_INSTANCE = new SystemPropertiesCredentialsProvider();
+    private static final ProfileCredentialsProvider PROFILE_CREDENTIALS_PROVIDER = new ProfileCredentialsProvider();
+    private static final EC2ContainerCredentialsProviderWrapper EC2_PROVIDER_WRAPPER = new EC2ContainerCredentialsProviderWrapper();
+
+    private AwsS3CredentialsProviderChain(List<? extends AWSCredentialsProvider> credentialsProviders) {
+        super(credentialsProviders);
+    }
+
+    public static AwsS3CredentialsProviderChain.Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final ArrayList<AWSCredentialsProvider> credentialProviders = new ArrayList<>();
+        private String profile;
+
+        Builder() {
+            profile = null;
+        }
+
+        public AwsS3CredentialsProviderChain build() {
+            return new AwsS3CredentialsProviderChain(credentialProviders);
+        }
+
+        public Builder addProfileCredentialsProvider(String profile) {
+            credentialProviders.add(new ProfileCredentialsProvider(profile));
+            return this;
+        }
+
+        public Builder addDefaultProviders() {
+            credentialProviders.add(ENV_PROVIDER_INSTANCE);
+            credentialProviders.add(SYS_PROVIDER_INSTANCE);
+            credentialProviders.add(PROFILE_CREDENTIALS_PROVIDER);
+            credentialProviders.add(EC2_PROVIDER_WRAPPER);
+            return this;
+        }
+
+        public Builder addCredentials(AWSCredentials credentials) {
+            return addCredentialsProvider(new AWSStaticCredentialsProvider(credentials));
+        }
+
+        public Builder addCredentialsProvider(AWSCredentialsProvider provider) {
+            credentialProviders.add(provider);
+            return this;
+        }
+    }
+}

--- a/src/main/java/com/emc/ecs/sync/storage/s3/AwsS3Storage.java
+++ b/src/main/java/com/emc/ecs/sync/storage/s3/AwsS3Storage.java
@@ -20,6 +20,7 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.event.ProgressEventType;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -84,7 +85,15 @@ public class AwsS3Storage extends AbstractS3Storage<AwsS3Config> {
         Assert.hasText(config.getBucketName(), "bucketName is required");
         Assert.isTrue(config.getBucketName().matches("[A-Za-z0-9._-]+"), config.getBucketName() + " is not a valid bucket name");
 
-        AWSCredentials creds = new BasicAWSCredentials(config.getAccessKey(), config.getSecretKey());
+        AWSCredentials creds;
+
+        if (config.getSessionToken() != null && config.getSessionToken().length() > 0) {
+            creds = new BasicSessionCredentials(config.getAccessKey(), config.getSecretKey(), config.getSessionToken());
+        }
+        else {
+            creds = new BasicAWSCredentials(config.getAccessKey(), config.getSecretKey());
+        }
+
         ClientConfiguration cc = new ClientConfiguration();
 
         if (config.getProtocol() != null)

--- a/src/main/java/com/emc/ecs/sync/storage/s3/AwsS3Storage.java
+++ b/src/main/java/com/emc/ecs/sync/storage/s3/AwsS3Storage.java
@@ -82,7 +82,10 @@ public class AwsS3Storage extends AbstractS3Storage<AwsS3Config> {
     public void configure(SyncStorage source, Iterator<SyncFilter> filters, SyncStorage target) {
         super.configure(source, filters, target);
 
-        if (!(config.getUseDefaultCredentialsProvider() || config.getProfile() != null) || config.getSessionToken() != null) {
+        if (!(config.getUseDefaultCredentialsProvider() || config.getProfile() != null)
+            || config.getSessionToken() != null
+            || config.getAccessKey() != null
+            || config.getSecretKey() != null) {
             Assert.hasText(config.getAccessKey(), "accessKey is required");
             Assert.hasText(config.getSecretKey(), "secretKey is required");
             Assert.isTrue(config.getSessionToken() == null || config.getSessionToken().length() == 0,
@@ -104,10 +107,11 @@ public class AwsS3Storage extends AbstractS3Storage<AwsS3Config> {
                 new BasicSessionCredentials(config.getAccessKey(), config.getSecretKey(), config.getSessionToken()));
         }
 
+        if (config.getProfile() != null && config.getProfile().length() > 0) {
+            providerChainBuilder.addProfileCredentialsProvider(config.getProfile());
+        }
+
         if (config.getUseDefaultCredentialsProvider()) {
-            if (config.getProfile() != null && config.getProfile().length() > 0) {
-                providerChainBuilder.addProfileCredentialsProvider(config.getProfile());
-            }
             providerChainBuilder.addDefaultProviders();
         }
 


### PR DESCRIPTION
Proposed changes:
- Replace static auth for AWS S3 with an auth chain credentials provider
- Add enabling STS tokens to the job request XML
- Add profiles to the job request XML
- Add the default credentials chain to the job request XML
- Update the payload assertions to allow credentials to be omitted when the default chain is enabled
- Update the payload assertions to not require credentials when a profile name is selected
- Update the payload assertions to require key and secret when the session token is submitted
- Added unit tests to validate added functionality and assertions
---
DCL-972
